### PR TITLE
Replaced Romberg integration in calc_kappa_ave to improve accuracy for SIEs

### DIFF
--- a/calcein.c
+++ b/calcein.c
@@ -558,7 +558,7 @@ double calc_kappa_ave(double r, double x0, double y0, int lensid)
   y0_calkap_sav = y0;
   r_calkap_sav = r;
 
-  return gsl_romberg3(calc_kappa_ave_func, 0.0, 2.0 * M_PI, TOL_ROMBERG_AVE) / (2.0 * M_PI);
+  return gsl_qgaus(calc_kappa_ave_func, 0.0, 2.0 * M_PI) / (2.0 * M_PI);
 }
 
 double calc_kappa_ave_func(double t)


### PR DESCRIPTION
I have replaced the gsl_romberg3 integration with gsl_qgaus.

While calculating the azimuthal average of kappa for an SIE for a single galaxy the Romberg integration (gsl_romberg3) first evaluates the integrand at 0 and 2 pi. Because the mass profile is SIE, these two values are exactly the same. Romberg then evaluates at the midpoint (pi), which is also equal due to elliptical symmetry. Since all evaluation points produce the same result, Romberg assumes convergence and stops subdividing further, causing low accuracy for higher ellipticity.

Replacing Romberg with Gaussian quadrature (gsl_qgaus) evaluates the function more robustly across the interval and fixes the accuracy issue.